### PR TITLE
Store proofs in the DB 

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -6,54 +6,32 @@ use serde::{
 // mongodb database models for the job data
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Verification {    
-    pub image_id: String
+pub enum Kind {
+    Aggregate,
+
+    Assumption,
+
+    Groth16
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Proof {    
-    pub prover: String,
+    pub job_id: Bson,
 
+    pub prover: Vec<u8>,
     pub blob: Option<Vec<u8>>,
+    pub hash: String,
 
-    pub hash: u128,
-}
+    pub round_number: Option<u32>,
+    
+    pub kind: Kind,
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Segment {    
-    pub id: u32,
-
-    //@ rename to job_oid: ObjectId
-    pub job_id: Bson,
-
-    // a succinct receipt(proved & lifted)
-    pub proof: Proof,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Join {
-    pub pair_id: u32,
-
-    pub job_id: Bson,
-
-    pub round: u32,
-
-
-    pub proof: Proof,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Groth16 {
-    pub job_id: Bson,
-
-    pub proof: Proof,
+    pub batch_id: String
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Job {    
-    pub id: u128,
+    pub id: String,
 
-    pub verification: Verification,
-
-    pub snark_proof: Option<Proof>,
+    pub image_id: [u8; 32],
 }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -35,8 +35,10 @@ pub struct Proof {
 
 #[derive(Debug, Clone)]
 pub enum Input {    
+    // blob, used for the first round(segments)
     Blob(Vec<u8>),
 
+    // (prover, proof)
     Token(Vec<u8>, Proof)
 }
 
@@ -304,8 +306,8 @@ impl Pipeline {
         })
     }
 
-    pub fn num_agg_rounds(&self) -> usize {
-        self.agg_rounds.len()
+    pub fn cur_agg_round_number(&self) -> usize {
+        self.agg_rounds.last().unwrap().number
     }
 
     pub fn assign_agg_batch(&mut self, prover: &Vec<u8>) -> Option<(u128, Vec<Input>)> {


### PR DESCRIPTION
This PR enable proof logging to a local mongodb instance in a new format.